### PR TITLE
remove check for $Zone in Remove-MachineAccount as it is not required

### DIFF
--- a/Powermad.ps1
+++ b/Powermad.ps1
@@ -1029,7 +1029,7 @@ function Remove-MachineAccount
         throw
     }
 
-    if(!$DomainController -or !$Domain -or !$Zone)
+    if(!$DomainController -or !$Domain)
     {
 
         try


### PR DESCRIPTION
Remove-MachineAccount checked for $Zone variable but it doesn't appear to be set/used anywhere within the function. Having this there caused issues when trying to run the function from a non-domain context.